### PR TITLE
Hotfix: Conflict between Enum and Variable Class Name

### DIFF
--- a/Assign.cpp
+++ b/Assign.cpp
@@ -46,7 +46,7 @@ void Assign::_execute(Entity* entity) {
 		_model->trace(Util::TraceLevel::TL_blockInternal, "Let \"" + let->getDestination() + "\" = " + std::to_string(value));
 		/* TODO: this is NOT the best way to do it (enum comparision) */
 		if (let->getDestinationType() == DestinationType::Variable) {
-			::Variable* myvar = (::Variable*) this->_model->getInfrastructure(Util::TypeOf<::Variable>(), let->getDestination());
+			Variable* myvar = (Variable*) this->_model->getInfrastructure(Util::TypeOf<Variable>(), let->getDestination());
 			myvar->setValue(value);
 		} else if (let->getDestinationType() == DestinationType::Attribute) {
 			entity->setAttributeValue(let->getDestination(), value);

--- a/Assign.h
+++ b/Assign.h
@@ -19,7 +19,7 @@
 class Assign : public ModelComponent {
 public:
 
-	enum DestinationType { /* TODO: +- an enun is not a good idea. Should be a list of possible classes, so TypeOf could be set */
+	enum class DestinationType { /* TODO: +- an enun is not a good idea. Should be a list of possible classes, so TypeOf could be set */
 		Attribute, Variable
 	};
 
@@ -50,7 +50,7 @@ public:
 			return _expression;
 		}
 	private:
-		DestinationType _destinationType = Attribute;
+		DestinationType _destinationType = DestinationType::Attribute;
 		std::string _destination = "";
 		std::string _expression = "";
 


### PR DESCRIPTION
Previously, creating an **unscoped enum** caused the conflict with the
name of the Variable class.

Solution: Change the **unscoped enum** to a **scoped enum**, that is, use
**enum class** instead of just **enum**. This will force anyone who uses
the enumerator to explicitly specify the DestinationType scope.